### PR TITLE
fix: Move tarball back into directory

### DIFF
--- a/create-tarball.sh
+++ b/create-tarball.sh
@@ -3,3 +3,4 @@
 base=$(basename $PWD)
 cd ..
 tar -czf $base.tar.gz $base
+mv $base.tar.gz $base/


### PR DESCRIPTION
- Minor adjustment to the tarball script that moves the output back into the directory from which it is run