### PR TITLE
fix: Change the new file copyright template

### DIFF
--- a/RedbubbleHomework.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/RedbubbleHomework.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+//  Copyright © ___YEAR___ Redbubble. All rights reserved.
+// </string>
+</dict>
+</plist>


### PR DESCRIPTION
Removes the candidates name from the file when they create a new file, to help preserve anonymity

- https://useyourloaf.com/blog/changing-xcode-header-comment/
- https://help.apple.com/xcode/mac/9.0/index.html?localePath=en.lproj#/dev7fe737ce0